### PR TITLE
Update Guava library to version 20.0.

### DIFF
--- a/core/src/main/java/com/github/dieterdepaepe/jsearch/datastructure/priority/FibonacciHeap.java
+++ b/core/src/main/java/com/github/dieterdepaepe/jsearch/datastructure/priority/FibonacciHeap.java
@@ -5,10 +5,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.Iterators;
 import com.google.common.collect.Ordering;
 
-import java.util.AbstractCollection;
-import java.util.Collection;
-import java.util.Comparator;
-import java.util.Iterator;
+import java.util.*;
 
 /**
  * A <a href="http://en.wikipedia.org/wiki/Fibonacci_heap">Fibonacci heap</a> is an efficient priority queue which
@@ -94,7 +91,7 @@ public class FibonacciHeap<K, V> implements Iterable<FibonacciHeapEntry<K, V>> {
             minTreeRoot = newTreeRoot;
             newTreeRoot.nextSibling = newTreeRoot;
             newTreeRoot.prevSibling = newTreeRoot;
-        } else  {
+        } else {
             insertBehind(newTreeRoot, minTreeRoot);
             if (keyComparator.compare(newTreeRoot.key, minTreeRoot.key) <= -1)
                 minTreeRoot = newTreeRoot;
@@ -418,7 +415,7 @@ public class FibonacciHeap<K, V> implements Iterable<FibonacciHeapEntry<K, V>> {
      */
     public Iterator<FibonacciHeapEntry<K, V>> iterator() {
         if (isEmpty())
-            return Iterators.emptyIterator();
+            return Collections.emptyIterator();
         else
             return new FibonacciHeapIterator<>(minTreeRoot);
     }

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
       <dependency>
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>
-        <version>15.0</version>
+        <version>20.0</version>
       </dependency>
       <dependency>
         <groupId>org.testng</groupId>


### PR DESCRIPTION
Updated the Guava version number in the parent pom.xml and changed a discontinued API (Iterators#emptyIterator) to the Java 7 alternative (Collections#emptyIterator).